### PR TITLE
Set requirement for Kodi 17

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
        version="0.0.2"
        provider-name="Hagai Cohen">
   <requires>
-    <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="xbmc.gui" version="5.12.0"/>
     <import addon="script.module.requests" version="2.12.4"/>
     <import addon="script.common.plugin.cache" version="2.5.5"/>
   </requires>


### PR DESCRIPTION
Based on http://kodi.wiki/view/addon.xml replace <import addon=xmbc.python with <import addon=xmbc.gui for 5.12.0 so we require at least kodi 17 because if the required ssl for python